### PR TITLE
[Fix] 하단 네비게이션 탭 선택 상태 수정

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -20,12 +20,39 @@ export function BottomNavigation({ items }: BottomNavigationProps) {
         return null
     }
 
-    const bgcolor = (path: string) =>
-        location.pathname === path ? '#FFE2D9' : 'white'
+    // 각 탭에 속하는 경로들 정의
+    const tabRoutes: Record<string, string[]> = {
+        '/': ['/', '/search-restaurant', '/noti', '/upload', '/post'],
+        '/matching': ['/matching', '/send-invitation', '/read-invitation'],
+        '/profile': [
+            '/profile',
+            '/coupon',
+            '/profile-edit',
+            '/bob-check-history',
+            '/challenge',
+            '/friend-profile'
+        ],
+        '/meeting': ['/meeting']
+    }
+
+    // 현재 경로가 해당 탭에 속하는지 확인
+    const isActive = (tabPath: string) => {
+        const routes = tabRoutes[tabPath]
+        if (!routes) return location.pathname === tabPath
+
+        return routes.some(route =>
+            route === '/'
+                ? location.pathname === '/'
+                : location.pathname === route ||
+                  location.pathname.startsWith(route + '/')
+        )
+    }
+
+    const bgcolor = (path: string) => (isActive(path) ? '#FFE2D9' : 'white')
     const strokecolor = (path: string) =>
-        location.pathname === path ? '#FF480B' : '#B7B7B7'
+        isActive(path) ? '#FF480B' : '#B7B7B7'
     const textColor = (path: string) =>
-        location.pathname === path ? 'text-primary-main' : 'text-gray-600'
+        isActive(path) ? 'text-primary-main' : 'text-gray-600'
 
     return (
         <nav


### PR DESCRIPTION
## 📌 개요

하단 네비게이션에서 현재 경로에 맞는 탭 활성화 로직을 수정합니다.

## ✅ 변경 사항

- **각 탭에 속하는 경로 정의** (`a0162d9`)
    - 각 네비게이션 탭에 해당하는 경로 매핑 추가
    - 서브 경로 포함 시에도 상위 탭 활성화 처리

## 🧪 테스트

- [ ] 각 페이지 접근 시 올바른 탭 하이라이트 확인
- [ ] 서브 페이지에서도 상위 탭 활성화 확인